### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 ## ------------------------
 
 PACKAGE = $(shell basename $(shell pwd))
-PREFIX=
-PIP=pip
+PREFIX ?=
+PIP ?= pip
 ifeq ($(CONDA_PREFIX),)
 	PREFIX=sudo -H
 	PIP=pip-sirius


### PR DESCRIPTION
Make possible to overwrite PIP and PREFIX variables.
In order to install the package using the `make` ansible module inside the conda environment.