### PR TITLE
Add hdf5 Support

### DIFF
--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -143,7 +143,8 @@ def save_hdf5(data, fname, overwrite=False, makedirs=False, compress=False):
         makedirs (bool, optional): create dir, if it does not exist.
             Defaults to False.
         compress (bool, optional): If True, the arrays in the file will be
-            saved in compressed format, using gzip library. Defaults to False.
+            saved in compressed format, using hdf5 standard compression with
+            the `gzip` filter. Defaults to False.
 
     Raises:
         FileExistsError: in case `overwrite` is `False` and file exists.
@@ -169,7 +170,7 @@ def save_hdf5(data, fname, overwrite=False, makedirs=False, compress=False):
 
 
 def load_hdf5(fname):
-    """Load HDF5 file.
+    """Load a HDF5 file as whole to the memory as a python object.
 
     Args:
         fname (str): Name of the file to load. If the extension of the file is

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -116,10 +116,11 @@ def load_pickle(fname):
         data (any builtin type): content of file as a python object.
 
     """
-    func = _gzip.open if is_gzip_file(fname) else open
-
     if not fname.endswith('.pickle'):
         fname += '.pickle'
+
+    func = _gzip.open if is_gzip_file(fname) else open
+
     with func(fname, 'rb') as fil:
         data = _pickle.load(fil)
     return data

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -291,7 +291,7 @@ def get_package_string(package):
 # ------------------------- HELPER METHODS ------------------------------------
 _TYPES2SAVE = (int, float, complex, str, bytes, bool)
 _STRTYPES = {typ.__name__ for typ in _TYPES2SAVE}
-_NPTYPES = (_np.int_, _np.float, _np.complex_, _np.bool_)
+_NPTYPES = (_np.int_, _np.float_, _np.complex_, _np.bool_)
 
 
 def _save_recursive_hdf5(fil, path, obj, compress):

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -321,11 +321,12 @@ def _load_recursive_hdf5(fil):
     """."""
     typ = fil.attrs['type']
     if typ == 'list':
-        return [_load_recursive_hdf5(obj) for obj in fil.values()]
+        return [_load_recursive_hdf5(fil[str(i)]) for i in range(len(fil))]
     elif typ == 'tuple':
-        return tuple([_load_recursive_hdf5(obj) for obj in fil.values()])
+        return tuple([
+            _load_recursive_hdf5(fil[str(i)]) for i in range(len(fil))])
     elif typ == 'set':
-        return {_load_recursive_hdf5(obj) for obj in fil.values()}
+        return {_load_recursive_hdf5(fil[str(i)]) for i in range(len(fil))}
     elif typ == 'dict':
         return {k: _load_recursive_hdf5(obj) for k, obj in fil.items()}
     elif typ == 'NoneType':

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -7,9 +7,9 @@ import pickle as _pickle
 import subprocess as _subprocess
 import pkg_resources as _pkg_resources
 from types import ModuleType as _ModuleType
+import gzip as _gzip
 
 import h5py as _h5py
-import gzip as _gzip
 import numpy as _np
 
 _HASSIRIUSPY = False

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -97,13 +97,17 @@ def save_pickle(data, fname, overwrite=False, makedirs=False, compress=False):
     """
     if not fname.endswith('.pickle'):
         fname += '.pickle'
+
     if not overwrite and _os.path.isfile(fname):
         raise FileExistsError(f'file {fname} already exists.')
+
     if makedirs:
         dirname = _os.path.dirname(fname)
         if not _os.path.exists(dirname):
             _os.makedirs(dirname)
-    with open(fname, 'wb') as fil:
+
+    func = _gzip.open if compress else open
+    with func(fname, 'wb') as fil:
         _pickle.dump(data, fil)
 
 

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -342,5 +342,5 @@ def _load_recursive_hdf5(fil):
         type_ = getattr(_builtins, typ)
         return type_(fil[()])
     else:
-        type_ = getattr(_np, typ)
-        return type_(fil[()])
+        # h5py automatically handles convertion of scalar numpy types
+        return fil[()]

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -1,5 +1,6 @@
 """Useful functions."""
 import os as _os
+import builtins as _builtins
 import importlib as _importlib
 from collections import namedtuple as _namedtuple
 from functools import partial as _partial
@@ -290,8 +291,8 @@ def get_package_string(package):
 
 
 # ------------------------- HELPER METHODS ------------------------------------
-_TYPES2SAVE = (int, float, complex, str, bytes, bool)
-_STRTYPES = {typ.__name__ for typ in _TYPES2SAVE}
+_BUILTINTYPES = (int, float, complex, str, bytes, bool)
+_BUILTINNAMES = {typ.__name__ for typ in _BUILTINTYPES}
 _NPTYPES = (_np.int_, _np.float_, _np.complex_, _np.bool_)
 
 
@@ -301,7 +302,7 @@ def _save_recursive_hdf5(fil, path, obj, compress):
         fil.create_dataset(path, data=obj, compression=compress)
     elif isinstance(obj, str):  # Handle SiriusPVName
         fil[path] = str(obj)
-    elif isinstance(obj, _TYPES2SAVE + _NPTYPES):
+    elif isinstance(obj, _BUILTINTYPES + _NPTYPES):
         fil[path] = obj
     elif obj is None:
         fil[path] = 'None'
@@ -338,9 +339,9 @@ def _load_recursive_hdf5(fil):
         return fil[()].decode()
     elif _HASSIRIUSPY and typ == 'SiriusPVName':
         return _SiriusPVName(fil[()].decode())
-    elif typ in _STRTYPES:
-        exec('type_ = '+typ)
-        return locals()['type_'](fil[()])
+    elif typ in _BUILTINNAMES:
+        type_ = getattr(_builtins, typ)
+        return type_(fil[()])
     else:
-        exec('type_ = _np.'+typ)
-        return locals()['type_'](fil[()])
+        type_ = getattr(_np, typ)
+        return type_(fil[()])

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -13,11 +13,6 @@ import gzip as _gzip
 import h5py as _h5py
 import numpy as _np
 
-_HASSIRIUSPY = False
-if _importlib.util.find_spec('siriuspy'):
-    from siriuspy.namesys import SiriusPVName as _SiriusPVName
-    _HASSIRIUSPY = True
-
 
 def generate_random_numbers(n_part, dist_type='exp', cutoff=3):
     """Generate random numbers with a cutted off dist_type distribution.
@@ -337,8 +332,8 @@ def _load_recursive_hdf5(fil):
         return fil[()]
     elif typ == 'str':
         return fil[()].decode()
-    elif _HASSIRIUSPY and typ == 'SiriusPVName':
-        return _SiriusPVName(fil[()].decode())
+    elif typ == 'SiriusPVName':
+        return fil[()].decode()
     elif typ in _BUILTINNAMES:
         type_ = getattr(_builtins, typ)
         return type_(fil[()])

--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -8,8 +8,7 @@ import pkg_resources as _pkg_resources
 from types import ModuleType as _ModuleType
 
 import h5py as _h5py
-import gzip
-
+import gzip as _gzip
 import numpy as _np
 
 
@@ -117,7 +116,7 @@ def load_pickle(fname):
         data (any builtin type): content of file as a python object.
 
     """
-    func = gzip.open if is_gzip_file(fname) else open
+    func = _gzip.open if is_gzip_file(fname) else open
 
     if not fname.endswith('.pickle'):
         fname += '.pickle'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy>=1.18
 matplotlib>=3.1.2
+gzip>=1.10.0
+h5py>=3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.18
 matplotlib>=3.1.2
-h5py>=3.8.0
+h5py>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.18
 matplotlib>=3.1.2
-gzip>=1.10.0
 h5py>=3.8.0


### PR DESCRIPTION
This PR features:
 - add support to save and load pickle files in compressed mode, with `gzip`;
 - add support of saving and loading data in HDF5 file format;

I tested the methods with the following code snippet:

```python3
import numpy as np
import h5py
import os

from mathphys import functions as funcs


def compare_data(data1, data2):
    if not isinstance(data1, type(data2))  and not isinstance(data2, type(data1)):
        return False

    if isinstance(data1, (list, tuple, set)):
        if len(data1) != len(data2):
            print(type(data1).__name__ + ' with different lengths')
            return False
        for i, (d1, d2) in enumerate(zip(data1, data2)):
            if not compare_data(d1, d2):
                print(i)
                return False
    elif isinstance(data1, dict):
        if len(data1) != len(data2):
            print('dict with different lengths')
            return False
        for k, v in data1.items():
            if not compare_data(v, data2[k]):
                print(k)
                return False
    elif isinstance(data1, np.ndarray):
        if not np.equal(data1, data2).all():
            print(data1, data2)
            return False
    else:
        if data1 != data2:
            print(data1, data2)
            return False
    return True


data = {
    'x': 'astring',
    'z': [1,2,3,np.int64(4)],
    'w': [dict(a=2, b=dict(c=3, d=4)), {1, 2, 3}, (4, 5, 6)],
    'y': np.arange(10),
    'p': None,
    's': np.zeros(10, dtype=bool),
    'a': True,
    'd': {'z': np.ones((2,3)), 'b': b'bytestring'}
    }

print(data)
fname = 'test.h5'
funcs.save_hdf5(data, filename)
dd = funcs.load_hdf5(filename)
print(dd)

fname = 'SI-03C3:PS-FCV.pickle'
# fname = 'fofb_rate_fofb_ref_respmat_run1.pickle'
# fname = 'scanx_m0700_p0300_11pts_scany_m0400_p0000_5pts_run2.pickle'
data = funcs.load_pickle(fname)
funcs.save_pickle(data, 'test', overwrite=True, compress=False)
funcs.save_pickle(data, 'test_comp', overwrite=True, compress=True)
funcs.save_hdf5(data, 'test', overwrite=True, compress=False)
funcs.save_hdf5(data, 'test_comp', overwrite=True, compress=True)
!ls -lth test*.{pickle,h5}

dt_pk = funcs.load_pickle('test')
dt_pkz = funcs.load_pickle('test_comp')
dt_h5 = funcs.load_hdf5('test')
dt_h5z = funcs.load_hdf5('test_comp')

# Compare data:
print(compare_data(dt_pk, data))
print(compare_data(dt_pkz, data))
print(compare_data(dt_h5, data))
print(compare_data(dt_h5z, data))
```

where the files:
```
 - SI-03C3:PS-FCV.pickle (SysId)
 - fofb_rate_fofb_ref_respmat_run1.pickle (Orbit acquisitions)
 - scanx_m0700_p0300_11pts_scany_m0400_p0000_5pts_run2.pickle (NLK Bumps)
```
are data from machine studies.

One interesting result, is that the compressed version of the `SysId` file using HDF5 **and pickle** is much smaller (3 times) than the uncompressed version:
```
-rw-r--r-- 1 fernando facs  37M set 29 16:58 test_comp.h5
-rw-r--r-- 1 fernando facs 119M set 29 16:58 test.h5
-rw-r--r-- 1 fernando facs  34M set 29 16:58 test_comp.pickle
-rw-r--r-- 1 fernando facs 119M set 29 16:58 test.pickle
```
