### PR TITLE
Move h5py import to specific function.

### DIFF
--- a/mathphys/functions.py
+++ b/mathphys/functions.py
@@ -10,7 +10,12 @@ import pkg_resources as _pkg_resources
 from types import ModuleType as _ModuleType
 import gzip as _gzip
 
-import h5py as _h5py
+try:
+    import h5py as _h5py
+except:
+    _h5py = None
+
+
 import numpy as _np
 
 


### PR DESCRIPTION
This makes code that uses this library less dependent on specific imports.